### PR TITLE
Use large brackets around matrix example.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
         "servant": "servant"
       },
       "locked": {
-        "lastModified": 1756231625,
-        "narHash": "sha256-OLyARpxkotqjMXw7Io2cofR+LQeuyj7x1E0XlEpgCdo=",
+        "lastModified": 1756251749,
+        "narHash": "sha256-KQ8ALGzJ3k1l0hYxsB2wrQotDn8KXQiaVIVR+c53dkA=",
         "owner": "dmjio",
         "repo": "miso",
-        "rev": "7b19eb8cdd48ab51ca14fed4bf99944a74a6c8ee",
+        "rev": "7a92ee2a6311554109a7333ad42357c37e3e92d1",
         "type": "github"
       },
       "original": {

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -139,11 +139,10 @@ main = run $ startApp vcomp
                     ]
                     [ mi_ [] ["A"]
                     , mo_ [] ["="]
-                    , mfenced_
-                        [ close_ "]"
-                        , open_ "["
-                        ]
-                        [ mtable_
+                    , mrow_
+                      []
+                        [ mo_ [] [ "[" ]
+                        , mtable_
                             []
                             [ mtr_
                                 []
@@ -164,6 +163,7 @@ main = run $ startApp vcomp
                                 , mtd_ [] [mn_ [] ["9"]]
                                 ]
                             ]
+                        , mo_ [] [ "]" ]
                         ]
                     ]
                 ]


### PR DESCRIPTION
This removes `mfenced`, in favor of `mo_` to introduce large brackets.

cc @alpmestan